### PR TITLE
Update with new aikido method name.

### DIFF
--- a/src/JointTrajectoryControllerBase.cpp
+++ b/src/JointTrajectoryControllerBase.cpp
@@ -263,8 +263,8 @@ void JointTrajectoryControllerBase::goalCallback(GoalHandle goalHandle)
   // Convert the JointTrajectory message to a format that we can execute.
   std::shared_ptr<aikido::trajectory::Spline> trajectory;
   try {
-    trajectory = aikido::control::ros::convertJointTrajectory(mControlledSpace,
-                                                              goal->trajectory);
+    trajectory = aikido::control::ros::toSplineJointTrajectory(mControlledSpace,
+                                                               goal->trajectory);
   } catch (const std::runtime_error& e) {
     Result result;
     result.error_code = Result::INVALID_GOAL;


### PR DESCRIPTION
`convertJointTrajectory` was renamed to `toSplineJointTrajectory` in https://github.com/personalrobotics/aikido/pull/149.