### PR TITLE
MoveUntilTouchTopicControlle reports  F/T connection loss

### DIFF
--- a/include/rewd_controllers/MoveUntilTouchTopicController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchTopicController.hpp
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <mutex>
+  #include <chrono>
 #include <actionlib/server/action_server.h>
 #include <actionlib/client/simple_action_client.h>
 #include <hardware_interface/force_torque_sensor_interface.h>
@@ -114,6 +115,8 @@ private:
 
   // \brief If the torque is higher than this threshold, the controller aborts.
   std::atomic<double> mTorqueThreshold;
+
+   std::chrono::time_point<std::chrono::steady_clock> timeOfLastSensorDataReceived;
 
   /**
    * \brief Callback for pr_control_msgs::SetForceTorqueThresholdAction.

--- a/include/rewd_controllers/MoveUntilTouchTopicController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchTopicController.hpp
@@ -3,7 +3,7 @@
 
 #include <atomic>
 #include <mutex>
-  #include <chrono>
+#include <chrono>
 #include <actionlib/server/action_server.h>
 #include <actionlib/client/simple_action_client.h>
 #include <hardware_interface/force_torque_sensor_interface.h>
@@ -79,7 +79,7 @@ private:
   using FTThresholdGoalHandle = FTThresholdActionServer::GoalHandle;
   using FTThresholdResult = pr_control_msgs::SetForceTorqueThresholdResult;
   using TareActionClient = actionlib::ActionClient<pr_control_msgs::TriggerAction>;
-  
+
   // \brief Protects mForce and mTorque from simultaneous access.
   std::mutex mForceTorqueDataMutex;
 
@@ -116,7 +116,8 @@ private:
   // \brief If the torque is higher than this threshold, the controller aborts.
   std::atomic<double> mTorqueThreshold;
 
-   std::chrono::time_point<std::chrono::steady_clock> timeOfLastSensorDataReceived;
+  // \brief Keeps track of the last update time
+ std::chrono::time_point<std::chrono::steady_clock> mTimeOfLastSensorDataReceived;
 
   /**
    * \brief Callback for pr_control_msgs::SetForceTorqueThresholdAction.

--- a/include/rewd_controllers/MoveUntilTouchTopicController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchTopicController.hpp
@@ -15,6 +15,7 @@
 #include <rewd_controllers/MultiInterfaceController.hpp>
 #include <rewd_controllers/JointTrajectoryControllerBase.hpp>
 
+
 namespace rewd_controllers
 {
 
@@ -74,6 +75,8 @@ protected:
   bool shouldStopExecution(std::string& message) override;
 
 private:
+  static constexpr std::chrono::milliseconds MAX_DELAY = std::chrono::milliseconds(400);
+
   using SetFTThresholdAction = pr_control_msgs::SetForceTorqueThresholdAction;
   using FTThresholdActionServer = actionlib::ActionServer<SetFTThresholdAction>;
   using FTThresholdGoalHandle = FTThresholdActionServer::GoalHandle;

--- a/src/MoveUntilTouchTopicController.cpp
+++ b/src/MoveUntilTouchTopicController.cpp
@@ -93,14 +93,14 @@ void MoveUntilTouchTopicController::forceTorqueDataCallback(const geometry_msgs:
   mTorque.x() = msg.wrench.torque.x;
   mTorque.y() = msg.wrench.torque.y;
   mTorque.z() = msg.wrench.torque.z;
-  timeOfLastSensorDataReceived = std::chrono::steady_clock::now();
+  mTimeOfLastSensorDataReceived = std::chrono::steady_clock::now();
 }
 
 //=============================================================================
 void MoveUntilTouchTopicController::taringTransitionCallback(const TareActionClient::GoalHandle& goalHandle) {
   if (goalHandle.getResult() && goalHandle.getResult()->success) {
     ROS_INFO("Taring completed!");
-    timeOfLastSensorDataReceived = std::chrono::steady_clock::now();
+    mTimeOfLastSensorDataReceived = std::chrono::steady_clock::now();
     mTaringCompleted.store(true);
   }
 }
@@ -129,7 +129,8 @@ void MoveUntilTouchTopicController::update(const ros::Time& time,
                                       const ros::Duration& period)
 {
   if (mTaringCompleted.load()
-      && (std::chrono::steady_clock::now() - timeOfLastSensorDataReceived > std::chrono::milliseconds(400))) {
+      && (std::chrono::steady_clock::now() - mTimeOfLastSensorDataReceived > std::chrono::milliseconds(400)))
+  {
     throw std::runtime_error("Lost connection to F/T sensor!");
   }
 
@@ -157,16 +158,20 @@ bool MoveUntilTouchTopicController::shouldStopExecution(std::string& message)
   bool forceThresholdExceeded = mForce.norm() >= forceThreshold;
   bool torqueThresholdExceeded = mTorque.norm() >= torqueThreshold;
 
-  
+
   if (forceThresholdExceeded) {
     std::stringstream messageStream;
-    messageStream << "Force Threshold exceeded!   Threshold: " << forceThreshold << "   Force: " << mForce.x() << ", " << mForce.y() << ", " << mForce.z();
+    messageStream << "Force Threshold exceeded!   Threshold: "
+    << forceThreshold << "   Force: " << mForce.x()
+    << ", " << mForce.y() << ", " << mForce.z();
     message = messageStream.str();
     ROS_WARN(message.c_str());
   }
   if (torqueThresholdExceeded) {
     std::stringstream messageStream;
-    messageStream << "Torque Threshold exceeded!   Threshold: " << torqueThreshold << "   Torque: " << mTorque.x() << ", " << mTorque.y() << ", " << mTorque.z();
+    messageStream << "Torque Threshold exceeded!   Threshold: "
+    << torqueThreshold << "   Torque: " << mTorque.x()
+    << ", " << mTorque.y() << ", " << mTorque.z();
     message = messageStream.str();
     ROS_WARN(message.c_str());
   }

--- a/src/MoveUntilTouchTopicController.cpp
+++ b/src/MoveUntilTouchTopicController.cpp
@@ -158,7 +158,6 @@ bool MoveUntilTouchTopicController::shouldStopExecution(std::string& message)
   bool forceThresholdExceeded = mForce.norm() >= forceThreshold;
   bool torqueThresholdExceeded = mTorque.norm() >= torqueThreshold;
 
-
   if (forceThresholdExceeded) {
     std::stringstream messageStream;
     messageStream << "Force Threshold exceeded!   Threshold: "

--- a/src/MoveUntilTouchTopicController.cpp
+++ b/src/MoveUntilTouchTopicController.cpp
@@ -129,7 +129,7 @@ void MoveUntilTouchTopicController::update(const ros::Time& time,
                                       const ros::Duration& period)
 {
   if (mTaringCompleted.load()
-      && (std::chrono::steady_clock::now() - mTimeOfLastSensorDataReceived > std::chrono::milliseconds(400)))
+      && (std::chrono::steady_clock::now() - mTimeOfLastSensorDataReceived > MAX_DELAY))
   {
     throw std::runtime_error("Lost connection to F/T sensor!");
   }


### PR DESCRIPTION
`MoveUntilTouchTopicController` keeps track of the last sensor update time and throws runtime error if no signal is received within `MAX_DELAY` time.