### PR TITLE
Fix for MoveUntilTouchTopicController 

### DIFF
--- a/include/rewd_controllers/MoveUntilTouchTopicController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchTopicController.hpp
@@ -75,7 +75,6 @@ protected:
   bool shouldStopExecution(std::string& message) override;
 
 private:
-  static constexpr std::chrono::milliseconds MAX_DELAY = std::chrono::milliseconds(400);
 
   using SetFTThresholdAction = pr_control_msgs::SetForceTorqueThresholdAction;
   using FTThresholdActionServer = actionlib::ActionServer<SetFTThresholdAction>;

--- a/src/MoveUntilTouchTopicController.cpp
+++ b/src/MoveUntilTouchTopicController.cpp
@@ -3,6 +3,8 @@
 #include <functional>
 #include <pluginlib/class_list_macros.h>
 
+static const std::chrono::milliseconds MAX_DELAY = std::chrono::milliseconds(400);
+
 namespace rewd_controllers
 {
 //=============================================================================


### PR DESCRIPTION
Minor fix for the last merge. It moves `MAX_DELAY` const to be in `MoveUntilTouchTopicController.cpp`