### PR TITLE
Check for SO(2) prior to PID

### DIFF
--- a/.ci/before_install_catkin.sh
+++ b/.ci/before_install_catkin.sh
@@ -8,4 +8,4 @@ cd "${HOME}/workspace"
 git clone https://github.com/personalrobotics/pr-cleanroom.git scripts
 
 ./scripts/internal-setup.sh
-curl -sS "${DISTRIBUTION}" | ./scripts/internal-convert.py > distribution.yml # required for private repos
+curl -sS "${DISTRIBUTION}" > distribution.yml # public repo, no internal-convert

--- a/src/JointAdapter.cpp
+++ b/src/JointAdapter.cpp
@@ -92,10 +92,8 @@ void JointVelocityAdapter::update(
 
   if (commandedVelocity > mUpperVelLimit || commandedVelocity < mLowerVelLimit)
   {
-    std::cout << "Desired Position: " << desiredPosition << std::endl;
-    std::cout << "Actual Position: " << actualPosition << std::endl;
-    std::cout << "Desired Velocity: " << desiredVelocity << std::endl;
-    std::cout << "Actual Position: " << actualVelocity << std::endl;
+    ROS_ERROR_STREAM("Velocity limit exceeded wtih desired pose " << desiredPosition 
+      << " and actual pose " << actualPosition);
     std::stringstream ss;
     ss << "Overall velocity [" << desiredVelocity + pidVelocity << "] is beyond the velocity"
       << " limits [" << mLowerVelLimit << ", " << mUpperVelLimit << "]" << std::endl;

--- a/src/JointAdapter.cpp
+++ b/src/JointAdapter.cpp
@@ -77,7 +77,6 @@ void JointVelocityAdapter::update(
     double actualVelocity, double desiredVelocity,
     double /*nominalEffort*/)
 {
-  // TODO: Handle position wrapping on SO(2) joints.
   const auto pidVelocity = mPid.computeCommand(
     desiredPosition - actualPosition,
     desiredVelocity - actualVelocity,
@@ -90,6 +89,10 @@ void JointVelocityAdapter::update(
 
   if (desiredVelocity + pidVelocity > 5.0)
   {
+    std::cout << "Desired Position: " << desiredPosition << std::endl;
+    std::cout << "Actual Position: " << actualPosition << std::endl;
+    std::cout << "Desired Velocity: " << desiredVelocity << std::endl;
+    std::cout << "Actual Position: " << actualVelocity << std::endl;
     std::stringstream ss;
     ss << "Overall velocity " << desiredVelocity + pidVelocity << std::endl;
     throw std::range_error(ss.str());

--- a/src/JointTrajectoryControllerBase.cpp
+++ b/src/JointTrajectoryControllerBase.cpp
@@ -318,7 +318,7 @@ void JointTrajectoryControllerBase::updateStep(const ros::Time& time,
     auto jointSpace = mControlledSpace->getJointSpace(idof);
     auto r1Joint = std::dynamic_pointer_cast<const R1Joint>(jointSpace);
     if(!r1Joint) {
-      desiredPos = std::fmod(deisredPos, 2.0 * M_PI);
+      desiredPos = std::fmod(desiredPos, 2.0 * M_PI);
       actualPos = std::fmod(actualPos, 2.0 * M_PI);
       if(desiredPos - actualPos > M_PI) {
         actualPos += 2*M_PI;

--- a/src/JointTrajectoryControllerBase.cpp
+++ b/src/JointTrajectoryControllerBase.cpp
@@ -256,6 +256,7 @@ void JointTrajectoryControllerBase::updateStep(const ros::Time& time,
         auto jointSpace = mControlledSpace->getJointSpace(index);
         auto r1Joint = std::dynamic_pointer_cast<const R1Joint>(jointSpace);
         if(!r1Joint) {
+          diff = std::fmod(diff, 2.0 * M_PI);
           if(diff > M_PI) {
             diff = 2 * M_PI - diff;
           }
@@ -317,6 +318,8 @@ void JointTrajectoryControllerBase::updateStep(const ros::Time& time,
     auto jointSpace = mControlledSpace->getJointSpace(idof);
     auto r1Joint = std::dynamic_pointer_cast<const R1Joint>(jointSpace);
     if(!r1Joint) {
+      desiredPos = std::fmod(deisredPos, 2.0 * M_PI);
+      actualPos = std::fmod(actualPos, 2.0 * M_PI);
       if(desiredPos - actualPos > M_PI) {
         actualPos += 2*M_PI;
       } else if(desiredPos - actualPos < -M_PI) {

--- a/src/JointTrajectoryControllerBase.cpp
+++ b/src/JointTrajectoryControllerBase.cpp
@@ -252,7 +252,7 @@ void JointTrajectoryControllerBase::updateStep(const ros::Time& time,
         std::size_t index = mControlledSkeleton->getIndexOf(dof);
         auto diff = std::abs(mDesiredPosition[index] - mActualPosition[index]);
 
-        // Check for SO2:
+        // Check for SO2
         auto jointSpace = mControlledSpace->getJointSpace(index);
         auto r1Joint = std::dynamic_pointer_cast<const R1Joint>(jointSpace);
         if(!r1Joint) {
@@ -321,9 +321,9 @@ void JointTrajectoryControllerBase::updateStep(const ros::Time& time,
       desiredPos = std::fmod(desiredPos, 2.0 * M_PI);
       actualPos = std::fmod(actualPos, 2.0 * M_PI);
       if(desiredPos - actualPos > M_PI) {
-        actualPos += 2*M_PI;
+        desiredPos -= 2*M_PI;
       } else if(desiredPos - actualPos < -M_PI) {
-        actualPos -= 2*M_PI;
+        desiredPos += 2*M_PI;
       }
     }
 


### PR DESCRIPTION
Currently, `rewd_controllers` cannot handle SO(2) trajectories.
For example, if the current joint position is `-3`, and the next waypoint is at `3` on an SO(2) joint, the error used by the PID controller is `6` rather than `~0.28`.

This both causes unintended behavior (extra rotations during the trajectory) and often trips the hard joint velocity constraints, killing the controller.

This PR fixes this issue by properly `fmod`-ing the requested position at each waypoint.