### PR TITLE
Add Cartesian Velocity Controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rewd_controllers)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
 include_directories("include")
 
@@ -66,6 +66,7 @@ add_library("${PROJECT_NAME}" SHARED
   src/MoveUntilTouchController.cpp
   src/MoveUntilTouchTopicController.cpp
   src/FTThresholdClient.cpp
+  src/MoveUntilTouchCartVelocityController.cpp
 )
 target_link_libraries("${PROJECT_NAME}"
   ${DART_LIBRARIES}

--- a/include/rewd_controllers/MoveUntilTouchCartVelocityController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchCartVelocityController.hpp
@@ -1,0 +1,110 @@
+#ifndef REWD_CONTROLLERS_MOVEUNTILTOUCHCARTVELOCITY_HPP_
+#define REWD_CONTROLLERS_MOVEUNTILTOUCHCARTVELOCITY_HPP_
+
+#include <memory>
+#include <atomic>
+#include <controller_interface/multi_interface_controller.h>
+#include <dart/dynamics/dynamics.hpp>
+#include <ros/node_handle.h>
+#include "helpers.hpp"
+#include <actionlib/server/action_server.h>
+#include <realtime_tools/realtime_buffer.h>
+
+#include <pr_hardware_interfaces/CartesianVelocityInterface.h>
+#include <pr_control_msgs/SetCartesianVelocityAction.h>
+
+namespace rewd_controllers
+{
+class MoveUntilTouchCartVelocityController
+    : public controller_interface::
+          MultiInterfaceController<pr_hardware_interfaces::CartesianVelocityInterface,
+                                   hardware_interface::JointStateInterface,
+                                   hardware_interface::JointModeInterface>
+{
+public:
+  MoveUntilTouchCartVelocityController();
+  virtual ~MoveUntilTouchCartVelocityController();
+
+  /** \brief The init function is called to initialize the controller from a
+   * non-realtime thread with a pointer to the hardware interface, itself,
+   * instead of a pointer to a RobotHW.
+   *
+   * \param robot The specific hardware interface used by this controller.
+   *
+   * \param n A NodeHandle in the namespace from which the controller
+   * should read its configuration, and where it should set up its ROS
+   * interface.
+   *
+   * \returns True if initialization was successful and the controller
+   * is ready to be started.
+   */
+  bool init(hardware_interface::RobotHW* robot, ros::NodeHandle& n);
+
+  /*!
+   * \brief Issues commands to the joint. Should be called at regular intervals
+   */
+  void update(const ros::Time& time, const ros::Duration& period);
+
+  /** \brief This is called from within the realtime thread just before the
+   * first call to \ref update
+   *
+   * \param time The current time
+   */
+  void starting(const ros::Time& time) override;
+  void stopping(const ros::Time& time) override;
+
+protected:
+  using Action = pr_control_msgs::SetCartesianVelocityAction;
+  using ActionServer = actionlib::ActionServer<Action>;
+  using GoalHandle = ActionServer::GoalHandle;
+
+  using Result = pr_control_msgs::SetCartesianVelocityResult;
+
+  using JointModes = hardware_interface::JointCommandModes;
+
+private:
+  /** \brief Actionlib callback to accept new Goal.
+   */
+  void goalCallback(GoalHandle goalHandle);
+
+  /** \brief Actionlib callback to cancel previously accepted goal.
+   */
+  void cancelCallback(GoalHandle goalHandle);
+
+  /** \brief Contains all data needed to execute the currently
+   * requested velocity. Shared between real time and non-real
+   * time threads.
+   *
+   * This structure must be used AS A WHOLE, and reassigned
+   * in its entirety. Assigning to individual components
+   * is UNSAFE with the exception of the mCompleted atomic.
+   */
+  struct CartVelContext {
+    ros::Time mStartTime;
+    ros::Duration mDuration;
+    Eigen::VectorXd mDesiredVelocity;
+    GoalHandle mGoalHandle;
+    std::atomic_bool mCompleted;
+  };
+  using CartVelContextPtr = std::shared_ptr<CartVelContext>;
+
+  // For position feedback:
+  dart::dynamics::SkeletonPtr mSkeleton;
+  std::unique_ptr<SkeletonJointStateUpdater> mSkeletonUpdater;
+
+  // Action server variables
+  std::unique_ptr<ActionServer> mActionServer;
+
+  // TODO: It would be better to use std::atomic<std::shared_ptr<T>> here.
+  // However, this will not be implemented until C++20.
+  realtime_tools::RealtimeBox<CartVelContextPtr> mCurrentCartVel;
+
+  // For communication with robot
+  pr_hardware_interfaces::CartesianVelocityHandle mCartVelHandle;
+  hardware_interface::JointModeHandle mJointModeHandle;
+  JointModes lastMode;
+};
+
+}  // namespace
+
+#endif

--- a/include/rewd_controllers/helpers.hpp
+++ b/include/rewd_controllers/helpers.hpp
@@ -7,10 +7,13 @@
 #include <dart/dynamics/dynamics.hpp>
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/joint_mode_interface.h>
 #include <hardware_interface/robot_hw.h>
 #include <ros/node_handle.h>
 #include "JointAdapter.hpp"
 #include "JointAdapterFactory.hpp"
+
+#include <pr_hardware_interfaces/CartesianVelocityInterface.h>
 
 namespace rewd_controllers {
 

--- a/src/MoveUntilTouchCartVelocityController.cpp
+++ b/src/MoveUntilTouchCartVelocityController.cpp
@@ -1,0 +1,194 @@
+#include <rewd_controllers/MoveUntilTouchCartVelocityController.hpp>
+
+#include <hardware_interface/hardware_interface.h>
+#include <pluginlib/class_list_macros.h>
+#include <dart/dynamics/dynamics.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
+
+#include <pr_hardware_interfaces/CartesianVelocityInterface.h>
+#include <pr_control_msgs/SetCartesianVelocityAction.h>
+
+#define SE3_SIZE 6
+
+namespace rewd_controllers
+{
+namespace
+{
+//=============================================================================
+std::vector<double> toVector(const Eigen::VectorXd& input)
+{
+  return std::vector<double>{input.data(), input.data() + input.size()};
+}
+
+}  // namespace
+
+//=============================================================================
+MoveUntilTouchCartVelocityController::MoveUntilTouchCartVelocityController()
+  : MultiInterfaceController(true)  // allow_optional_interfaces
+{}
+
+//=============================================================================
+MoveUntilTouchCartVelocityController::~MoveUntilTouchCartVelocityController() {}
+
+//=============================================================================
+bool MoveUntilTouchCartVelocityController::init(hardware_interface::RobotHW *robot,
+                                         ros::NodeHandle &n)
+{
+  using hardware_interface::JointStateInterface;
+  using hardware_interface::JointModeInterface;
+  using pr_hardware_interfaces::CartesianVelocityInterface;
+
+  // Load the URDF as a Skeleton.
+  mSkeleton = loadRobotFromParameter(n, "robot_description_parameter");
+  if (!mSkeleton) return false;
+
+  // Have skeleton update from joint state interface
+  const auto jointStateInterface = robot->get<JointStateInterface>();
+  if (!jointStateInterface) {
+    ROS_ERROR("Unable to get JointStateInterface from RobotHW instance.");
+    return false;
+  }
+
+  mSkeletonUpdater.reset(
+      new SkeletonJointStateUpdater{mSkeleton, jointStateInterface});
+
+
+  // Load control interfaces and handles
+  const auto jointModeInterface = robot->get<JointModeInterface>();
+  if (!jointModeInterface) {
+    ROS_ERROR("Unable to get JointModeInterface from RobotHW instance.");
+    return false;
+  }
+
+  try {
+    mJointModeHandle = jointModeInterface->getHandle("joint_mode");
+  } catch (const hardware_interface::HardwareInterfaceException &e) {
+    ROS_ERROR_STREAM("Unable to get joint mode interface for robot");
+    return false;
+  }
+
+  const auto cartVelInterface = robot->get<CartesianVelocityInterface>();
+  if (!cartVelInterface) {
+    ROS_ERROR("Unable to get CartesianVelocityInterface from RobotHW instance.");
+    return false;
+  }
+
+  try {
+    mCartVelHandle = cartVelInterface->getHandle("cart_vel");
+  } catch (const hardware_interface::HardwareInterfaceException &e) {
+    ROS_ERROR_STREAM("Unable to get cartesian velocity interface for robot.");
+    return false;
+  }
+
+  // init local vars
+  mCurrentCartVel.set(nullptr);
+
+  // TODO: Initialize FT sensor
+
+  // Start the action server. This must be last.
+  using std::placeholders::_1;
+  mActionServer.reset(new actionlib::ActionServer<Action>{
+      n, "cart_velocity",
+      std::bind(&MoveUntilTouchCartVelocityController::goalCallback, this, _1),
+      std::bind(&MoveUntilTouchCartVelocityController::cancelCallback, this, _1),
+      false});
+  mActionServer->start();
+
+  ROS_INFO("MoveUntilTouchCartVelocityController initialized successfully");
+  return true;
+}
+
+//=============================================================================
+void MoveUntilTouchCartVelocityController::starting(const ros::Time& time)
+{
+  // Set Joint Mode to Other
+  lastMode = mJointModeHandle.getMode();
+  mJointModeHandle.setMode(JointModes::NOMODE);
+}
+
+//=============================================================================
+void MoveUntilTouchCartVelocityController::stopping(const ros::Time& time)
+{
+  // Return joint mode to what it was before
+  mJointModeHandle.setMode(lastMode);
+}
+
+//=============================================================================
+void MoveUntilTouchCartVelocityController::update(const ros::Time &time,
+                                           const ros::Duration &period)
+{
+  mSkeletonUpdater->update();
+
+  Eigen::VectorXd setVelocity;
+  setVelocity.resize(SE3_SIZE);
+  setVelocity.setZero();
+
+  // Load current command
+  std::shared_ptr<CartVelContext> context;
+  mCurrentCartVel.get(context);
+
+  if (context && !context->mCompleted.load())
+  {
+    // check duration
+    ros::Duration runTime = time - context->mStartTime;
+    if (runTime >= context->mDuration) {
+      // Successful run
+      Result result;
+      result.error_code = Result::SUCCESSFUL;
+      result.error_string = "";
+      context->mGoalHandle.setSucceeded(result);
+      context->mCompleted.store(true);
+    }
+    // TODO: check FT sensor
+    else {
+      setVelocity = context->mDesiredVelocity;
+    }
+  }
+
+  // Execute velocity command
+  mCartVelHandle.setCommand(toVector(setVelocity));
+}
+
+//=============================================================================
+void MoveUntilTouchCartVelocityController::goalCallback(GoalHandle goalHandle)
+{
+  const auto goal = goalHandle.getGoal();
+  ROS_INFO_STREAM("Received cartesian velocity '"
+                  << goalHandle.getGoalID().id << "'.");
+
+  // Setup the new trajectory.
+  const auto newContext = std::make_shared<CartVelContext>();
+  newContext->mStartTime = ros::Time::now();
+  newContext->mGoalHandle = goalHandle;
+  newContext->mDuration = goal->exec_time;
+  newContext->mDesiredVelocity.resize(SE3_SIZE);
+  newContext->mCompleted.store(false);
+
+  // Copy over velocity data
+  newContext->mDesiredVelocity(0) = goal->command.linear.x;
+  newContext->mDesiredVelocity(1) = goal->command.linear.y;
+  newContext->mDesiredVelocity(2) = goal->command.linear.z;
+  newContext->mDesiredVelocity(3) = goal->command.angular.x;
+  newContext->mDesiredVelocity(4) = goal->command.angular.y;
+  newContext->mDesiredVelocity(5) = goal->command.angular.z;
+
+  // TODO: add velocity checks
+
+  // We've accepted the goal
+  newContext->mGoalHandle.setAccepted();
+  mCurrentCartVel.set(newContext);
+}
+
+//=============================================================================
+void MoveUntilTouchCartVelocityController::cancelCallback(GoalHandle goalHandle)
+{
+  ROS_INFO_STREAM("Requesting cancelation of velocity '"
+                  << goalHandle.getGoalID().id << "'.");
+  goalHandle.setAccepted();
+  mCurrentCartVel.set(nullptr);
+}
+
+}  // namespace rewd_controllers
+
+PLUGINLIB_EXPORT_CLASS(rewd_controllers::MoveUntilTouchCartVelocityController,
+                       controller_interface::ControllerBase)


### PR DESCRIPTION
Add a Cartesian Velocity controller whose job is to forward twist commands to the robot (right now, the low level hardware interface is only available on JACO, not HERB).

Still a lot TODO: 
(1) Add optional force-torque interface to the controller.
(2) Add a higher-level function to `libada` for testing.
(3) Add proper `clang-format-6.0` support.