### PR TITLE
Separate FT-Thresholding functionality to separate server file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library("${PROJECT_NAME}" SHARED
   src/MoveUntilTouchController.cpp
   src/MoveUntilTouchTopicController.cpp
   src/FTThresholdClient.cpp
+  src/FTThresholdServer.cpp
 )
 target_link_libraries("${PROJECT_NAME}"
   ${DART_LIBRARIES}

--- a/include/rewd_controllers/FTThresholdClient.hpp
+++ b/include/rewd_controllers/FTThresholdClient.hpp
@@ -7,7 +7,7 @@
 
 namespace rewd_controllers {
 
-/// The FTThresholdClient configures the MoveUntilTouch(Topic)Controller's
+/// The FTThresholdClient configures all MoveUntilTouch- controllers'
 /// thresholds.
 /// When those thresholds are exceeded, the controller stops the movement.
 class FTThresholdClient {
@@ -16,16 +16,11 @@ public:
   /// Constructor.
   FTThresholdClient(const std::string &controllerThresholdTopic);
 
-  /// Sets the MoveUntilTouchControllers Thresholds.
-  /// Blocks until the threshold could be set successfully.
-  /// Can be aborted with !ros::ok(), in which case it returns false
-  bool trySetThresholdsRepeatedly(double forceThreshold,
-                                  double torqueThreshold);
-
-  /// Sets the MoveUntilTouchControllers thresholds.
+  /// Sets the MoveUntilTouch- thresholds.
+  /// Note: timeout is ignored if re-taring.
   /// Returns true if the thresholds were set successfully.
   bool setThresholds(double forceThreshold, double torqueThreshold,
-                     double timeout = 3.0);
+                     bool retare, double timeout = 3.0);
 
 private:
   std::unique_ptr<actionlib::SimpleActionClient<

--- a/include/rewd_controllers/FTThresholdClient.hpp
+++ b/include/rewd_controllers/FTThresholdClient.hpp
@@ -19,8 +19,8 @@ public:
   /// Sets the MoveUntilTouch- thresholds.
   /// Note: timeout is ignored if re-taring.
   /// Returns true if the thresholds were set successfully.
-  bool setThresholds(double forceThreshold, double torqueThreshold,
-                     bool retare, double timeout = 3.0);
+  bool setThresholds(double forceThreshold, double torqueThreshold, bool retare,
+                     double timeout = 3.0);
 
 private:
   std::unique_ptr<actionlib::SimpleActionClient<

--- a/include/rewd_controllers/FTThresholdServer.hpp
+++ b/include/rewd_controllers/FTThresholdServer.hpp
@@ -6,12 +6,16 @@
 // Default server name
 #define DEFAULT_SERVER "set_forcetorque_threshold" 
 
+#include <actionlib/client/simple_action_client.h>
 #include <actionlib/server/action_server.h>
+#include <geometry_msgs/WrenchStamped.h>
 #include <pr_control_msgs/SetForceTorqueThresholdAction.h>
+#include <pr_control_msgs/TriggerAction.h>
 #include <ros/ros.h>
 
 #include <atomic>
 #include <chrono>
+#include <mutex>
 
 namespace rewd_controllers {
 

--- a/include/rewd_controllers/FTThresholdServer.hpp
+++ b/include/rewd_controllers/FTThresholdServer.hpp
@@ -1,24 +1,24 @@
 #ifndef REWD_CONTROLLERS_FTTHRESHOLDSERVER_HPP
 #define REWD_CONTROLLERS_FTTHRESHOLDSERVER_HPP
 
-// Default force/torque limit
-#define DEFAULT_MAX 50.0
-// Default server name
-#define DEFAULT_SERVER "set_forcetorque_threshold" 
-
+#include <Eigen/Geometry>
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib/server/action_server.h>
 #include <geometry_msgs/WrenchStamped.h>
 #include <pr_control_msgs/SetForceTorqueThresholdAction.h>
 #include <pr_control_msgs/TriggerAction.h>
 #include <ros/ros.h>
-#include <Eigen/Geometry>
 
 #include <atomic>
 #include <chrono>
 #include <mutex>
 
 namespace rewd_controllers {
+
+// Default force/torque limit
+static const double DEFAULT_MAX = 50.0;
+// Default server name
+static const std::string DEFAULT_SERVER = "set_forcetorque_threshold";
 
 /// The FTThresholdClient configures all MoveUntilTouch- controllers'
 /// thresholds.
@@ -27,8 +27,7 @@ class FTThresholdServer {
 
 public:
   /// Constructor.
-  FTThresholdServer(ros::NodeHandle &nh,
-                    const std::string &wrenchTopic, 
+  FTThresholdServer(ros::NodeHandle &nh, const std::string &wrenchTopic,
                     const std::string &tareTopic,
                     double forceLimit = DEFAULT_MAX,
                     double torqueLimit = DEFAULT_MAX,
@@ -44,6 +43,16 @@ public:
    */
   bool shouldStopExecution(std::string &message);
 
+  /**
+   * \brief Call to start internal Action Server
+   */
+  void start();
+
+  /**
+   * \brief Call to stop internal Action Server
+   */
+  void stop();
+
 private:
   using SetFTThresholdAction = pr_control_msgs::SetForceTorqueThresholdAction;
   using FTThresholdActionServer = actionlib::ActionServer<SetFTThresholdAction>;
@@ -51,6 +60,12 @@ private:
   using FTThresholdResult = pr_control_msgs::SetForceTorqueThresholdResult;
   using TareActionClient =
       actionlib::SimpleActionClient<pr_control_msgs::TriggerAction>;
+
+  // \brief Node handle for re-init
+  std::unique_ptr<ros::NodeHandle> mNodeHandle;
+
+  // \brief Server name for re-init
+  std::string mServerName;
 
   // \brief Protects mForce and mTorque from simultaneous access.
   std::mutex mForceTorqueDataMutex;

--- a/include/rewd_controllers/FTThresholdServer.hpp
+++ b/include/rewd_controllers/FTThresholdServer.hpp
@@ -12,6 +12,7 @@
 #include <pr_control_msgs/SetForceTorqueThresholdAction.h>
 #include <pr_control_msgs/TriggerAction.h>
 #include <ros/ros.h>
+#include <Eigen/Geometry>
 
 #include <atomic>
 #include <chrono>
@@ -49,7 +50,7 @@ private:
   using FTThresholdGoalHandle = FTThresholdActionServer::GoalHandle;
   using FTThresholdResult = pr_control_msgs::SetForceTorqueThresholdResult;
   using TareActionClient =
-      actionlib::ActionClient<pr_control_msgs::TriggerAction>;
+      actionlib::SimpleActionClient<pr_control_msgs::TriggerAction>;
 
   // \brief Protects mForce and mTorque from simultaneous access.
   std::mutex mForceTorqueDataMutex;
@@ -75,9 +76,6 @@ private:
   // \brief Starts and handles the taring (calibration) process of the sensor
   std::unique_ptr<TareActionClient> mTareActionClient;
 
-  // \brief Keeps track of the goal status for the mTareActionClient
-  TareActionClient::GoalHandle mTareGoalHandle;
-
   // \brief ActionServer that enables others to set the force/torque thresholds
   std::unique_ptr<FTThresholdActionServer> mFTThresholdActionServer;
 
@@ -100,11 +98,6 @@ private:
    * \brief Called whenever a new Force/Torque message arrives on the ros topic
    */
   void forceTorqueDataCallback(const geometry_msgs::WrenchStamped &msg);
-
-  /**
-   * \brief Called whenever the status of taring changes
-   */
-  void taringTransitionCallback(const TareActionClient::GoalHandle &goalHandle);
 };
 } // namespace rewd_controllers
 

--- a/include/rewd_controllers/FTThresholdServer.hpp
+++ b/include/rewd_controllers/FTThresholdServer.hpp
@@ -1,0 +1,107 @@
+#ifndef REWD_CONTROLLERS_FTTHRESHOLDSERVER_HPP
+#define REWD_CONTROLLERS_FTTHRESHOLDSERVER_HPP
+
+// Default force/torque limit
+#define DEFAULT_MAX 50.0
+// Default server name
+#define DEFAULT_SERVER "set_forcetorque_threshold" 
+
+#include <actionlib/server/action_server.h>
+#include <pr_control_msgs/SetForceTorqueThresholdAction.h>
+#include <ros/ros.h>
+
+#include <atomic>
+#include <chrono>
+
+namespace rewd_controllers {
+
+/// The FTThresholdClient configures all MoveUntilTouch- controllers'
+/// thresholds.
+/// When those thresholds are exceeded, the controller stops the movement.
+class FTThresholdServer {
+
+public:
+  /// Constructor.
+  FTThresholdServer(ros::NodeHandle &nh,
+                    const std::string &wrenchTopic, 
+                    const std::string &tareTopic,
+                    double forceLimit = DEFAULT_MAX,
+                    double torqueLimit = DEFAULT_MAX,
+                    const std::string &serverName = DEFAULT_SERVER);
+
+  /**
+   * \brief Call from the update thread every control cycle, this method
+   * reads the current force/torque sensor state and compares with
+   * tolerances specified by the set_forcetorque_threshold service.
+   *
+   * \returns True if current wrench exceeds force/torque threshold. If a
+   * threshold is set to `0.0`, it is ignored.
+   */
+  bool shouldStopExecution(std::string &message);
+
+private:
+  using SetFTThresholdAction = pr_control_msgs::SetForceTorqueThresholdAction;
+  using FTThresholdActionServer = actionlib::ActionServer<SetFTThresholdAction>;
+  using FTThresholdGoalHandle = FTThresholdActionServer::GoalHandle;
+  using FTThresholdResult = pr_control_msgs::SetForceTorqueThresholdResult;
+  using TareActionClient =
+      actionlib::ActionClient<pr_control_msgs::TriggerAction>;
+
+  // \brief Protects mForce and mTorque from simultaneous access.
+  std::mutex mForceTorqueDataMutex;
+
+  // \brief The latest force of the sensor.
+  Eigen::Vector3d mForce;
+
+  // \brief The latest torque of the sensor.
+  Eigen::Vector3d mTorque;
+
+  // \brief Is true if the taring (or 'calibration') procedure is finished.
+  std::atomic_bool mTaringCompleted;
+
+  // \brief Sensor force limit. Cannot set a threshold higher than that.
+  double mForceLimit;
+
+  // \brief Sensor torque limit. Cannot set a threshold higher than that.
+  double mTorqueLimit;
+
+  // \brief Gets data from the force/torque sensor
+  ros::Subscriber mForceTorqueDataSub;
+
+  // \brief Starts and handles the taring (calibration) process of the sensor
+  std::unique_ptr<TareActionClient> mTareActionClient;
+
+  // \brief Keeps track of the goal status for the mTareActionClient
+  TareActionClient::GoalHandle mTareGoalHandle;
+
+  // \brief ActionServer that enables others to set the force/torque thresholds
+  std::unique_ptr<FTThresholdActionServer> mFTThresholdActionServer;
+
+  // \brief If the force is higher than this threshold, the controller aborts.
+  std::atomic<double> mForceThreshold;
+
+  // \brief If the torque is higher than this threshold, the controller aborts.
+  std::atomic<double> mTorqueThreshold;
+
+  // \brief Keeps track of the last update time
+  std::chrono::time_point<std::chrono::steady_clock>
+      mTimeOfLastSensorDataReceived;
+
+  /**
+   * \brief Callback for pr_control_msgs::SetForceTorqueThresholdAction.
+   */
+  void setForceTorqueThreshold(FTThresholdGoalHandle gh);
+
+  /**
+   * \brief Called whenever a new Force/Torque message arrives on the ros topic
+   */
+  void forceTorqueDataCallback(const geometry_msgs::WrenchStamped &msg);
+
+  /**
+   * \brief Called whenever the status of taring changes
+   */
+  void taringTransitionCallback(const TareActionClient::GoalHandle &goalHandle);
+};
+} // namespace rewd_controllers
+
+#endif

--- a/include/rewd_controllers/MoveUntilTouchTopicController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchTopicController.hpp
@@ -1,17 +1,10 @@
 #ifndef REWD_CONTROLLERS_MOVEUNTILTOUCHTOPICCONTROLLER_HPP_
 #define REWD_CONTROLLERS_MOVEUNTILTOUCHTOPICCONTROLLER_HPP_
 
-#include <actionlib/client/simple_action_client.h>
-#include <actionlib/server/action_server.h>
-#include <geometry_msgs/WrenchStamped.h>
-#include <hardware_interface/force_torque_sensor_interface.h>
-#include <hardware_interface/joint_command_interface.h>
-#include <mutex>
-#include <pr_control_msgs/SetForceTorqueThresholdAction.h>
-#include <pr_control_msgs/TriggerAction.h>
-#include <pr_hardware_interfaces/TriggerableInterface.h>
 #include <rewd_controllers/JointTrajectoryControllerBase.hpp>
 #include <rewd_controllers/MultiInterfaceController.hpp>
+
+#include <rewd_controllers/FTThresholdServer.hpp>
 
 namespace rewd_controllers {
 
@@ -71,7 +64,7 @@ protected:
 private:
   // \brief Force-Torque Thresholding Server
   std::shared_ptr<FTThresholdServer> mFTThresholdServer;
-  
+
 };
 
 } // namespace rewd_controllers

--- a/include/rewd_controllers/MoveUntilTouchTopicController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchTopicController.hpp
@@ -64,7 +64,6 @@ protected:
 private:
   // \brief Force-Torque Thresholding Server
   std::shared_ptr<FTThresholdServer> mFTThresholdServer;
-
 };
 
 } // namespace rewd_controllers

--- a/include/rewd_controllers/MoveUntilTouchTopicController.hpp
+++ b/include/rewd_controllers/MoveUntilTouchTopicController.hpp
@@ -3,8 +3,6 @@
 
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib/server/action_server.h>
-#include <atomic>
-#include <chrono>
 #include <geometry_msgs/WrenchStamped.h>
 #include <hardware_interface/force_torque_sensor_interface.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -71,67 +69,9 @@ protected:
   bool shouldStopExecution(std::string &message) override;
 
 private:
-  using SetFTThresholdAction = pr_control_msgs::SetForceTorqueThresholdAction;
-  using FTThresholdActionServer = actionlib::ActionServer<SetFTThresholdAction>;
-  using FTThresholdGoalHandle = FTThresholdActionServer::GoalHandle;
-  using FTThresholdResult = pr_control_msgs::SetForceTorqueThresholdResult;
-  using TareActionClient =
-      actionlib::ActionClient<pr_control_msgs::TriggerAction>;
-
-  // \brief Protects mForce and mTorque from simultaneous access.
-  std::mutex mForceTorqueDataMutex;
-
-  // \brief The latest force of the sensor.
-  Eigen::Vector3d mForce;
-
-  // \brief The latest torque of the sensor.
-  Eigen::Vector3d mTorque;
-
-  // \brief Is true if the taring (or 'calibration') procedure is finished.
-  std::atomic_bool mTaringCompleted;
-
-  // \brief Sensor force limit. Cannot set a threshold higher than that.
-  double mForceLimit;
-
-  // \brief Sensor torque limit. Cannot set a threshold higher than that.
-  double mTorqueLimit;
-
-  // \brief Gets data from the force/torque sensor
-  ros::Subscriber mForceTorqueDataSub;
-
-  // \brief Starts and handles the taring (calibration) process of the sensor
-  std::unique_ptr<TareActionClient> mTareActionClient;
-
-  // \brief Keeps track of the goal status for the mTareActionClient
-  TareActionClient::GoalHandle mTareGoalHandle;
-
-  // \brief ActionServer that enables others to set the force/torque thresholds
-  std::unique_ptr<FTThresholdActionServer> mFTThresholdActionServer;
-
-  // \brief If the force is higher than this threshold, the controller aborts.
-  std::atomic<double> mForceThreshold;
-
-  // \brief If the torque is higher than this threshold, the controller aborts.
-  std::atomic<double> mTorqueThreshold;
-
-  // \brief Keeps track of the last update time
-  std::chrono::time_point<std::chrono::steady_clock>
-      mTimeOfLastSensorDataReceived;
-
-  /**
-   * \brief Callback for pr_control_msgs::SetForceTorqueThresholdAction.
-   */
-  void setForceTorqueThreshold(FTThresholdGoalHandle gh);
-
-  /**
-   * \brief Called whenever a new Force/Torque message arrives on the ros topic
-   */
-  void forceTorqueDataCallback(const geometry_msgs::WrenchStamped &msg);
-
-  /**
-   * \brief Called whenever the status of taring changes
-   */
-  void taringTransitionCallback(const TareActionClient::GoalHandle &goalHandle);
+  // \brief Force-Torque Thresholding Server
+  std::shared_ptr<FTThresholdServer> mFTThresholdServer;
+  
 };
 
 } // namespace rewd_controllers

--- a/src/FTThresholdClient.cpp
+++ b/src/FTThresholdClient.cpp
@@ -19,8 +19,8 @@ FTThresholdClient::FTThresholdClient(
 
 //=============================================================================
 bool FTThresholdClient::setThresholds(double forceThreshold,
-                                      double torqueThreshold, 
-                                      bool retare, double timeout) {
+                                      double torqueThreshold, bool retare,
+                                      double timeout) {
   pr_control_msgs::SetForceTorqueThresholdGoal goal;
   goal.force_threshold = forceThreshold;
   goal.torque_threshold = torqueThreshold;
@@ -30,7 +30,7 @@ bool FTThresholdClient::setThresholds(double forceThreshold,
   // Ignore timeout if re-taring
   auto duration = retare ? ros::Duration(0.0) : ros::Duration(timeout);
   bool finished_before_timeout =
-        mFTThresholdActionClient->waitForResult(duration);
+      mFTThresholdActionClient->waitForResult(duration);
 
   actionlib::SimpleClientGoalState state = mFTThresholdActionClient->getState();
 

--- a/src/FTThresholdClient.cpp
+++ b/src/FTThresholdClient.cpp
@@ -18,25 +18,19 @@ FTThresholdClient::FTThresholdClient(
 }
 
 //=============================================================================
-bool FTThresholdClient::trySetThresholdsRepeatedly(double forceThreshold,
-                                                   double torqueThreshold) {
-  while (ros::ok()) {
-    if (setThresholds(forceThreshold, torqueThreshold))
-      return true;
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-  }
-  return false;
-}
-
-//=============================================================================
 bool FTThresholdClient::setThresholds(double forceThreshold,
-                                      double torqueThreshold, double timeout) {
+                                      double torqueThreshold, 
+                                      bool retare, double timeout) {
   pr_control_msgs::SetForceTorqueThresholdGoal goal;
   goal.force_threshold = forceThreshold;
   goal.torque_threshold = torqueThreshold;
+  goal.retare = retare;
   mFTThresholdActionClient->sendGoal(goal);
+
+  // Ignore timeout if re-taring
+  auto duration = retare ? ros::Duration(0.0) : ros::Duration(timeout);
   bool finished_before_timeout =
-      mFTThresholdActionClient->waitForResult(ros::Duration(timeout));
+        mFTThresholdActionClient->waitForResult(duration);
 
   actionlib::SimpleClientGoalState state = mFTThresholdActionClient->getState();
 

--- a/src/FTThresholdServer.cpp
+++ b/src/FTThresholdServer.cpp
@@ -54,6 +54,8 @@ void FTThresholdServer::start() { mFTThresholdActionServer->start(); }
 
 //=============================================================================
 // Max F/T sensor wait time
+// Arbitrary, can be changed in the future.
+// ATI runs at 120Hz, Gelsight could run as slow as 10Hz
 static const std::chrono::milliseconds MAX_DELAY =
     std::chrono::milliseconds(100);
 

--- a/src/FTThresholdServer.cpp
+++ b/src/FTThresholdServer.cpp
@@ -144,17 +144,17 @@ void FTThresholdServer::setForceTorqueThreshold(FTThresholdGoalHandle gh) {
     return;
   }
 
+  gh.setAccepted();
+
   // check that we are not already taring
   if (!mTaringCompleted.load()) {
     result.success = false;
     result.message =
         "Must wait until taring of force/torque sensor is complete "
         "before setting thresholds or sending trajectories.";
-    gh.setRejected(result);
+    gh.setAborted(result);
     return;
   }
-
-  gh.setAccepted();
 
   // Tare if requested
   if (goal->retare) {

--- a/src/FTThresholdServer.cpp
+++ b/src/FTThresholdServer.cpp
@@ -1,0 +1,181 @@
+#include "rewd_controllers/FTThresholdServer.hpp"
+
+namespace rewd_controllers {
+
+//=============================================================================
+FTThresholdServer::FTThresholdServer(ros::NodeHandle &nh,
+                    const std::string &wrenchTopic, 
+                    const std::string &tareTopic,
+                    double forceLimit = DEFAULT_MAX,
+                    double torqueLimit = DEFAULT_MAX,
+                    const std::string &serverName = DEFAULT_SERVER)
+    : mForceLimit{forceLimit} // allow_optional_interfaces
+    , mTorqueLimit{torqueLimit} {
+  // check that doubles are lock-free atomics
+  if (!mForceThreshold.is_lock_free()) {
+    ROS_WARN("Double atomics not lock-free on this system. Cannot guarantee "
+              "realtime safety.");
+  }
+
+  // subscribe to sensor data
+  mForceTorqueDataSub = nh.subscribe(
+      wrenchTopic, 1,
+      &FTThresholdServer::forceTorqueDataCallback, this);
+
+  // action client to kick off taring
+  mTareActionClient =
+      std::unique_ptr<TareActionClient>(new TareActionClient(nh, tareTopic));
+
+  // start action server
+  mFTThresholdActionServer.reset(
+      new actionlib::ActionServer<SetFTThresholdAction>{
+          nh, serverName,
+          std::bind(&FTThresholdServer::setForceTorqueThreshold,
+                    this, std::placeholders::_1),
+          false});
+  mFTThresholdActionServer->start();
+
+  // Set initial threshold to sensor limit
+  mForceThreshold.store(forceLimit);
+  mTorqueThreshold.store(torqueLimit);
+
+  // Do not require initial taring
+  mTaringCompleted.store(true);
+  mTimeOfLastSensorDataReceived = std::chrono::steady_clock::now();
+}
+
+//=============================================================================
+// Max F/T sensor wait time
+static const std::chrono::milliseconds MAX_DELAY =
+    std::chrono::milliseconds(100);
+
+bool FTThresholdServer::shouldStopExecution(std::string &message) {
+  // we must guarantee taring completes before moving
+  if (!mTaringCompleted.load()) {
+    ROS_WARN("taring not yet completed!");
+    return true;
+  }
+
+  // Watchdog
+  if ((std::chrono::steady_clock::now() - mTimeOfLastSensorDataReceived >
+       MAX_DELAY)) {
+    message = "Lost connection to F/T sensor!";
+    ROS_WARN(message.c_str());
+    return true;
+  }
+
+  double forceThreshold = mForceThreshold.load();
+  double torqueThreshold = mTorqueThreshold.load();
+
+  std::lock_guard<std::mutex> lock(mForceTorqueDataMutex);
+  bool forceThresholdExceeded = (mForce.norm() >= forceThreshold) && (forceThreshold != 0.0);
+  bool torqueThresholdExceeded = (mTorque.norm() >= torqueThreshold) && (torqueThreshold != 0.0);
+
+  if (forceThresholdExceeded) {
+    std::stringstream messageStream;
+    messageStream << "Force Threshold exceeded!   Threshold: " << forceThreshold
+                  << "   Force: " << mForce.x() << ", " << mForce.y() << ", "
+                  << mForce.z();
+    message = messageStream.str();
+    ROS_WARN(message.c_str());
+  }
+  if (torqueThresholdExceeded) {
+    std::stringstream messageStream;
+    messageStream << "Torque Threshold exceeded!   Threshold: "
+                  << torqueThreshold << "   Torque: " << mTorque.x() << ", "
+                  << mTorque.y() << ", " << mTorque.z();
+    message = messageStream.str();
+    ROS_WARN(message.c_str());
+  }
+
+  return forceThresholdExceeded || torqueThresholdExceeded;
+}
+
+//=============================================================================
+void FTThresholdServer::forceTorqueDataCallback(
+    const geometry_msgs::WrenchStamped &msg) {
+  std::lock_guard<std::mutex> lock(mForceTorqueDataMutex);
+  mForce.x() = msg.wrench.force.x;
+  mForce.y() = msg.wrench.force.y;
+  mForce.z() = msg.wrench.force.z;
+  mTorque.x() = msg.wrench.torque.x;
+  mTorque.y() = msg.wrench.torque.y;
+  mTorque.z() = msg.wrench.torque.z;
+  mTimeOfLastSensorDataReceived = std::chrono::steady_clock::now();
+}
+
+//=============================================================================
+void FTThresholdServer::taringTransitionCallback(
+    const TareActionClient::GoalHandle &goalHandle) {
+  if (goalHandle.getResult() && goalHandle.getResult()->success) {
+    ROS_INFO("Taring completed!");
+    mTimeOfLastSensorDataReceived = std::chrono::steady_clock::now();
+    mTaringCompleted.store(true);
+  }
+}
+
+//=============================================================================
+void FTThresholdServer::setForceTorqueThreshold(
+    FTThresholdGoalHandle gh) {
+  const auto goal = gh.getGoal();
+  ROS_INFO_STREAM("Setting thresholds: force = " << goal->force_threshold
+                                                 << ", torque = "
+                                                 << goal->torque_threshold);
+  FTThresholdResult result;
+  result.success = true;
+
+  // check threshold validity
+  if (goal->force_threshold > mForceLimit) {
+    result.success = false;
+    result.message = "Force threshold exceeds maximum sensor value.";
+  } else if (goal->force_threshold < 0.0) {
+    result.success = false;
+    result.message = "Force threshold must be positive or zero.";
+  } else if (goal->torque_threshold > mTorqueLimit) {
+    result.success = false;
+    result.message = "Torque threshold exceeds maximum sensor value.";
+  } else if (goal->torque_threshold < 0.0) {
+    result.success = false;
+    result.message = "Torque threshold must be positive or zero.";
+  }
+
+  if (!result.success) {
+    ROS_WARN_STREAM("FTThresholdServer: " << result.message);
+    gh.setRejected(result);
+    return;
+  }
+
+  gh.setAccepted();
+
+  // Tare if requested
+  if(goal->retare) {
+    // start asynchronous tare request
+    ROS_INFO("Starting Taring");
+    pr_control_msgs::TriggerGoal goal;
+    mTaringCompleted.store(false);
+    mTareActionClient->sendGoal(
+        goal,
+        boost::bind(&FTThresholdServer::taringTransitionCallback,
+                    this, _1));
+    // block until tared
+    mTareActionClient->waitForResult();
+  }
+
+  // check that we are not already taring
+  if (!mTaringCompleted.load()) {
+    result.success = false;
+    result.message =
+        "Must wait until taring of force/torque sensor is complete "
+        "before setting thresholds or sending trajectories.";
+    gh.setAccepted();
+    gh.setAborted(result);
+    return;
+  }
+
+  // Done, store new thresholds
+  mForceThreshold.store(goal->force_threshold);
+  mTorqueThreshold.store(goal->torque_threshold);
+  gh.setSucceeded(result);
+}
+
+} // namespace rewd_controllers

--- a/src/JointTrajectoryControllerBase.cpp
+++ b/src/JointTrajectoryControllerBase.cpp
@@ -252,7 +252,8 @@ void JointTrajectoryControllerBase::updateStep(const ros::Time &time,
       auto trajIt = mTrajectoryConstraints.find(dof->getName());
       auto goalIt = mGoalConstraints.find(dof->getName());
 
-      if (trajIt == mTrajectoryConstraints.end() && goalIt == mGoalConstraints.end())
+      if (trajIt == mTrajectoryConstraints.end() &&
+          goalIt == mGoalConstraints.end())
         continue;
 
       std::size_t index = mControlledSkeleton->getIndexOf(dof);

--- a/src/MoveUntilTouchTopicController.cpp
+++ b/src/MoveUntilTouchTopicController.cpp
@@ -54,11 +54,8 @@ bool MoveUntilTouchTopicController::init(hardware_interface::RobotHW *robot,
   }
 
   // Init FT Threshold Server
-  mFTThresholdServer.reset(new FTThresholdServer{nh,
-          ft_wrench_name,
-          ft_tare_name,
-          forceLimit,
-          torqueLimit});
+  mFTThresholdServer.reset(new FTThresholdServer{
+      nh, ft_wrench_name, ft_tare_name, forceLimit, torqueLimit});
 
   // initialize base trajectory controller
   return initController(robot, nh);
@@ -68,12 +65,18 @@ bool MoveUntilTouchTopicController::init(hardware_interface::RobotHW *robot,
 void MoveUntilTouchTopicController::starting(const ros::Time &time) {
   // start base trajectory controller
   startController(time);
+
+  // start FTThresholdServer
+  mFTThresholdServer->start();
 }
 
 //=============================================================================
 void MoveUntilTouchTopicController::stopping(const ros::Time &time) {
   // stop base trajectory controller
   stopController(time);
+
+  // stop FTThresholdServer
+  mFTThresholdServer->stop();
 }
 
 //=============================================================================


### PR DESCRIPTION
As we are now writing other controllers that require force-torque thresholding, it would be really nice to have this functionality in a separate, re-usable module. This change should be transparent to any users of `FTThresholdClient`.

Additionally, this cleans-up the re-taring interface, and no longer requires re-taring on controller start.
Previously, re-taring would happen automatically upon controller start, so if we ever wanted to swap controllers, before-and-after measurements would be biased relative to each other (for a specific example: this would mess up the acquisition detection framework, which requires force measurements both before and after food pickup).