### PR TITLE
Fix reference to base class ControllerState enum

### DIFF
--- a/include/rewd_controllers/MultiInterfaceController.hpp
+++ b/include/rewd_controllers/MultiInterfaceController.hpp
@@ -201,7 +201,7 @@ public:
    */
   MultiInterfaceController(bool allow_optional_interfaces = false)
       : allow_optional_interfaces_(allow_optional_interfaces) {
-    state_ = CONSTRUCTED;
+    state_ = ControllerBase::ControllerState::CONSTRUCTED;
   }
 
   virtual ~MultiInterfaceController() {}
@@ -300,7 +300,7 @@ protected:
                            ros::NodeHandle &controller_nh,
                            ClaimedResources &claimed_resources) {
     // check if construction finished cleanly
-    if (state_ != CONSTRUCTED) {
+    if (state_ != ControllerBase::ControllerState::CONSTRUCTED) {
       ROS_ERROR("Cannot initialize this controller because it failed to be "
                 "constructed");
       return false;
@@ -333,7 +333,7 @@ protected:
     // the controller is done when the controller is start()ed
 
     // initialization successful
-    state_ = INITIALIZED;
+    state_ = ControllerBase::ControllerState::INITIALIZED;
     return true;
   }
 


### PR DESCRIPTION
This PR fixes references to `controller_interface::ControllerBase::ControllerState` enum values.

This package doesn't compile right now because `CONSTRUCTED` doesn't refer to anything within scope. This is the compilation error I see on `master`:

```
/home/keyan/ros_ws/src/rewd_controllers/include/rewd_controllers/MultiInterfaceController.hpp: In constructor ‘rewd_controllers::MultiInterfaceController<T1, T2, T3, T4, T5, T6>::MultiInterfaceController(bool)’:
/home/keyan/ros_ws/src/rewd_controllers/include/rewd_controllers/MultiInterfaceController.hpp:204:14: error: ‘CONSTRUCTED’ was not declared in this scope; did you mean ‘C_STRUCT’?
  204 |     state_ = CONSTRUCTED;
      |              ^~~~~~~~~~~
      |              C_STRUCT
```